### PR TITLE
Add macros to create complex numbers

### DIFF
--- a/src/debug_simulator.rs
+++ b/src/debug_simulator.rs
@@ -1,4 +1,4 @@
-use crate::{Circuit, Instruction, SimpleSimulator};
+use crate::{cart, Circuit, Instruction, SimpleSimulator};
 use nalgebra::{Complex, DMatrix, DVector, dmatrix};
 use rand::{distr::weighted::WeightedIndex, prelude::*};
 
@@ -13,8 +13,8 @@ impl SimpleSimulator for DebugSimulator {
         let k = circuit.n_qubits;
 
         // Initial state assumed to be |000..>
-        let mut init_state = vec![Complex::ZERO; 1 << k];
-        init_state[0] = Complex::ONE;
+        let mut init_state = vec![cart!(0.0); 1 << k];
+        init_state[0] = cart!(1.0);
         let mut sim = DebugSimulator {
             states: vec![DVector::from_vec(init_state)],
         };
@@ -76,8 +76,8 @@ impl DebugSimulator {
         n_qubits: usize,
     ) -> DMatrix<Complex<f32>> {
         let ketbra = [
-            dmatrix![Complex::ONE, Complex::ZERO; Complex::ZERO, Complex::ZERO], // |0><0|
-            dmatrix![Complex::ZERO, Complex::ZERO; Complex::ZERO, Complex::ONE], // |1><1|
+            dmatrix![cart!(1.0), cart!(0.0); cart!(0.0), cart!(0.0)], // |0><0|
+            dmatrix![cart!(0.0), cart!(0.0); cart!(0.0), cart!(1.0)], // |1><1|
         ];
         let n_controls = controls.len();
 
@@ -114,7 +114,7 @@ pub enum SimpleError {
 
 #[cfg(test)]
 mod tests {
-    use crate::{Circuit, DebugSimulator, Instruction, SimpleSimulator};
+    use crate::{cart, Circuit, DebugSimulator, Instruction, SimpleSimulator};
     use nalgebra::{Complex, DMatrix, DVector, dmatrix, dvector};
     use std::f32::consts::FRAC_1_SQRT_2;
 
@@ -159,10 +159,10 @@ mod tests {
     fn textbook_cnot() -> DMatrix<Complex<f32>> {
         #[rustfmt::skip]
         let textbook_cnot: DMatrix::<Complex<f32>> = dmatrix![
-            Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE;
-            Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO;
+            cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0);
+            cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0);
         ];
         textbook_cnot
     }
@@ -176,14 +176,14 @@ mod tests {
     fn textbook_toffoli() -> DMatrix<Complex<f32>> {
         #[rustfmt::skip]
         let textbook_toffoli: DMatrix::<Complex<f32>> = dmatrix![
-            Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO;
+            cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0);
         ];
         textbook_toffoli
     }
@@ -198,14 +198,14 @@ mod tests {
     fn cnot_01() -> DMatrix<Complex<f32>> {
         #[rustfmt::skip]
         let cnot_01: DMatrix::<Complex<f32>> = dmatrix![
-            Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO;
+            cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0);
         ];
         cnot_01
     }
@@ -219,14 +219,14 @@ mod tests {
     fn cnot_02() -> DMatrix<Complex<f32>> {
         #[rustfmt::skip]
         let cnot_02: DMatrix::<Complex<f32>> = dmatrix![
-            Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO;
+            cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0);
         ];
         cnot_02
     }
@@ -240,14 +240,14 @@ mod tests {
     fn cnot_12() -> DMatrix<Complex<f32>> {
         #[rustfmt::skip]
         let cnot_12: DMatrix::<Complex<f32>> = dmatrix![
-            Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO;
+            cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0);
         ];
         cnot_12
     }
@@ -261,14 +261,14 @@ mod tests {
     fn h_0() -> DMatrix<Complex<f32>> {
         #[rustfmt::skip]
         let h_0: DMatrix::<Complex<f32>> = dmatrix![
-            Complex::new(FRAC_1_SQRT_2, 0.0),Complex::ZERO,Complex::ZERO,Complex::ZERO, Complex::new(FRAC_1_SQRT_2, 0.0), Complex::ZERO, Complex::ZERO, Complex::ZERO;
-            Complex::ZERO,Complex::new(FRAC_1_SQRT_2, 0.0),Complex::ZERO,Complex::ZERO, Complex::ZERO, Complex::new(FRAC_1_SQRT_2, 0.0), Complex::ZERO, Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::new(FRAC_1_SQRT_2, 0.0),Complex::ZERO, Complex::ZERO, Complex::ZERO, Complex::new(FRAC_1_SQRT_2, 0.0), Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::new(FRAC_1_SQRT_2, 0.0), Complex::ZERO, Complex::ZERO, Complex::ZERO, Complex::new(FRAC_1_SQRT_2, 0.0);
-            Complex::new(FRAC_1_SQRT_2, 0.0),Complex::ZERO,Complex::ZERO,Complex::ZERO,-Complex::new(FRAC_1_SQRT_2, 0.0), Complex::ZERO, Complex::ZERO, Complex::ZERO;
-            Complex::ZERO,Complex::new(FRAC_1_SQRT_2, 0.0),Complex::ZERO,Complex::ZERO, Complex::ZERO,-Complex::new(FRAC_1_SQRT_2, 0.0), Complex::ZERO, Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::new(FRAC_1_SQRT_2, 0.0),Complex::ZERO, Complex::ZERO, Complex::ZERO,-Complex::new(FRAC_1_SQRT_2, 0.0), Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::new(FRAC_1_SQRT_2, 0.0), Complex::ZERO, Complex::ZERO, Complex::ZERO,-Complex::new(FRAC_1_SQRT_2, 0.0);
+            cart!(FRAC_1_SQRT_2),cart!(0.0),cart!(0.0),cart!(0.0), cart!(FRAC_1_SQRT_2), cart!(0.0), cart!(0.0), cart!(0.0);
+            cart!(0.0),cart!(FRAC_1_SQRT_2),cart!(0.0),cart!(0.0), cart!(0.0), cart!(FRAC_1_SQRT_2), cart!(0.0), cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(FRAC_1_SQRT_2),cart!(0.0), cart!(0.0), cart!(0.0), cart!(FRAC_1_SQRT_2), cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(FRAC_1_SQRT_2), cart!(0.0), cart!(0.0), cart!(0.0), cart!(FRAC_1_SQRT_2);
+            cart!(FRAC_1_SQRT_2),cart!(0.0),cart!(0.0),cart!(0.0),-cart!(FRAC_1_SQRT_2), cart!(0.0), cart!(0.0), cart!(0.0);
+            cart!(0.0),cart!(FRAC_1_SQRT_2),cart!(0.0),cart!(0.0), cart!(0.0),-cart!(FRAC_1_SQRT_2), cart!(0.0), cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(FRAC_1_SQRT_2),cart!(0.0), cart!(0.0), cart!(0.0),-cart!(FRAC_1_SQRT_2), cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(FRAC_1_SQRT_2), cart!(0.0), cart!(0.0), cart!(0.0),-cart!(FRAC_1_SQRT_2);
         ];
         h_0
     }
@@ -281,14 +281,14 @@ mod tests {
 
     fn cnot_201() -> DMatrix<Complex<f32>> {
         let cnot_201: DMatrix<Complex<f32>> = dmatrix![
-            Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE;
-            Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
-            Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ONE,Complex::ZERO;
-            Complex::ZERO,Complex::ONE,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO,Complex::ZERO;
+            cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0);
+            cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
+            cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(1.0),cart!(0.0);
+            cart!(0.0),cart!(1.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0),cart!(0.0);
         ];
         cnot_201
     }
@@ -313,47 +313,47 @@ mod tests {
         let sim = DebugSimulator::build(circ).unwrap();
         assert!(sim.states.len() == 4);
         let psi0: DVector<Complex<f32>> = dvector![
-            Complex::ONE, // |000>
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO
+            cart!(1.0), // |000>
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0)
         ];
         assert_is_vector_equal!(psi0, sim.states[0].clone());
         let psi1: DVector<Complex<f32>> = dvector![
-            Complex::new(FRAC_1_SQRT_2, 0.0), //|000>
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::new(FRAC_1_SQRT_2, 0.0), //|100>
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO
+            cart!(FRAC_1_SQRT_2), //|000>
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(FRAC_1_SQRT_2), //|100>
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0)
         ];
         assert_is_vector_equal!(psi1, sim.states[1].clone());
         let psi2: DVector<Complex<f32>> = dvector![
-            Complex::new(FRAC_1_SQRT_2, 0.0), // |000>
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::new(FRAC_1_SQRT_2, 0.0), // |110>
-            Complex::ZERO
+            cart!(FRAC_1_SQRT_2), // |000>
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(FRAC_1_SQRT_2), // |110>
+            cart!(0.0)
         ];
         assert_is_vector_equal!(psi2, sim.states[2].clone());
         let psi3: DVector<Complex<f32>> = dvector![
-            Complex::new(FRAC_1_SQRT_2, 0.0), // |000>
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::ZERO,
-            Complex::new(FRAC_1_SQRT_2, 0.0) // |111>
+            cart!(FRAC_1_SQRT_2), // |000>
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(0.0),
+            cart!(FRAC_1_SQRT_2) // |111>
         ];
         assert_is_vector_equal!(psi3.clone(), sim.states[3].clone());
         assert_is_vector_equal!(psi3, sim.final_state());

--- a/src/ext.rs
+++ b/src/ext.rs
@@ -59,3 +59,17 @@ macro_rules! cart {
         Complex { re: $re, im: $im }
     };
 }
+
+#[macro_export]
+macro_rules! polar {
+    ($r: expr, $theta: expr) => {
+        Complex::from_polar($r, $theta)
+    };
+}
+
+#[macro_export]
+macro_rules! cexp {
+    ($exp: expr) => {
+        Complex::exp($exp)
+    };
+}

--- a/src/instruction.rs
+++ b/src/instruction.rs
@@ -1,5 +1,6 @@
 use nalgebra::{Complex, DMatrix, dmatrix};
 use std::{f32::consts::{FRAC_1_SQRT_2, PI}, vec};
+use crate::cart;
 
 pub enum Instruction {
     CNOT(usize, usize),
@@ -13,34 +14,34 @@ pub enum Instruction {
 
 impl Instruction {
     pub const PAULI_X_DATA: [Complex<f32>; 4] = [
-        Complex::new(0.0, 0.0), Complex::new(1.0, 0.0),
-        Complex::new(1.0, 0.0), Complex::new(0.0, 0.0),
+        cart!(0.0), cart!(1.0),
+        cart!(1.0), cart!(0.0),
     ];
 
     #[rustfmt::skip]
     pub const PAULI_Y_DATA: [Complex<f32>; 4] = [
-        Complex::new(0.0, 0.0), Complex::new(0.0, -1.0),
-        Complex::new(0.0, 1.0), Complex::new(0.0, 0.0),
+        cart!(0.0), cart!(0.0, -1.0),
+        cart!(0.0, 1.0), cart!(0.0),
     ];
 
     #[rustfmt::skip]
     pub const PAULI_Z_DATA: [Complex<f32>; 4] = [
-        Complex::new(1.0, 0.0), Complex::new(0.0, 0.0),
-        Complex::new(0.0, 0.0), Complex::new(-1.0, 0.0),
+        cart!(1.0), cart!(0.0),
+        cart!(0.0), cart!(-1.0, 0.0),
     ];
 
     #[rustfmt::skip]
     pub const HADAMARD_DATA: [Complex<f32>; 4] = [
-        Complex::new(FRAC_1_SQRT_2, 0.0), Complex::new(FRAC_1_SQRT_2, 0.0),
-        Complex::new(FRAC_1_SQRT_2, 0.0), Complex::new(-FRAC_1_SQRT_2, 0.0),
+        cart!(FRAC_1_SQRT_2, 0.0), cart!(FRAC_1_SQRT_2, 0.0),
+        cart!(FRAC_1_SQRT_2, 0.0), cart!(-FRAC_1_SQRT_2, 0.0),
     ];
 
     #[rustfmt::skip]
     pub const SWAP_DATA: [Complex<f32>; 16] = [
-        Complex::ONE, Complex::ZERO, Complex::ZERO, Complex::ZERO,
-        Complex::ZERO, Complex::ZERO, Complex::ONE, Complex::ZERO,
-        Complex::ZERO, Complex::ONE, Complex::ZERO, Complex::ZERO,
-        Complex::ZERO, Complex::ZERO, Complex::ZERO, Complex::ONE
+        cart!(1.0), cart!(0.0), cart!(0.0), cart!(0.0),
+        cart!(0.0), cart!(0.0), cart!(1.0), cart!(0.0),
+        cart!(0.0), cart!(1.0), cart!(0.0), cart!(0.0),
+        cart!(0.0), cart!(0.0), cart!(0.0), cart!(1.0)
     ];
 
     // Can add an argument specifying if we should include full matrix including for the control bits of the gate

--- a/src/simple_simulator.rs
+++ b/src/simple_simulator.rs
@@ -1,6 +1,6 @@
 use nalgebra::{Complex, DMatrix, DVector, Normed};
 use rand::{distr::weighted::WeightedIndex, prelude::*};
-use crate::{SimpleSimulator, Circuit, Instruction};
+use crate::{SimpleSimulator, Circuit, Instruction, cart};
 
 pub struct SimpleSimpleSimulator {
     state_vector: Vec<Complex<f32>>,
@@ -12,8 +12,8 @@ impl SimpleSimulator for SimpleSimpleSimulator {
     fn build(circuit: Circuit) -> Result<Self, Self::E> {
 
         let k = circuit.n_qubits;
-        let mut init_state_vector = vec![Complex::ZERO; 1 << k];
-        init_state_vector[0] = Complex::ONE;
+        let mut init_state_vector = vec![cart!(0.0); 1 << k];
+        init_state_vector[0] = cart!(1.0);
 
         let mut sim = SimpleSimpleSimulator {
             state_vector: init_state_vector,


### PR DESCRIPTION
Adds `cart!()`, and `polar!()` as a shorthand for `Complex::new(..., ...)`